### PR TITLE
Improved MemorySession

### DIFF
--- a/app.go
+++ b/app.go
@@ -22,7 +22,7 @@ type Application struct {
 	// Config provides configuration management.
 	Config *Config
 
-	sessionManager SessionManager
+	SessionManager SessionManager
 
 	// NotFoundHandler handles requests when no route is matched.
 	NotFoundHandler Handler
@@ -44,8 +44,6 @@ func New() *Application {
 	app.staticRouter = make(map[string][]string)
 	app.View = NewView()
 	app.Config = NewConfig(app)
-	// TODO: SessionManager should be configurable
-	app.sessionManager = NewMemorySessionManager()
 	// debug, _ := app.Config.GetBool("debug", false)
 	app.errorHandler = make(map[int]ErrorHandlerType)
 	app.MiddlewareChain = NewChain(defaultMiddlewares...)

--- a/app.go
+++ b/app.go
@@ -72,7 +72,6 @@ func (app *Application) handler(ctx *Context) {
 	params, handler := app.router.match(ctx.Request.URL.Path, ctx.Request.Method)
 	if handler != nil {
 		ctx.Params = params
-		ctx.retrieveSession()
 		handler(ctx)
 	} else {
 		app.handleError(ctx, 404)

--- a/context.go
+++ b/context.go
@@ -60,7 +60,7 @@ func NewContext(req *http.Request, res http.ResponseWriter, app *Application) *C
 }
 
 func (ctx *Context) generateSession() Session {
-	s, err := ctx.App.sessionManager.NewSession()
+	s, err := ctx.App.SessionManager.NewSession()
 	if err != nil {
 		panic(err)
 	}
@@ -75,7 +75,7 @@ func (ctx *Context) retrieveSession() {
 	if err != nil {
 		s = ctx.generateSession()
 	} else {
-		s, err = ctx.App.sessionManager.Session(sid)
+		s, err = ctx.App.SessionManager.Session(sid)
 		if err != nil {
 			s = ctx.generateSession()
 		}

--- a/context.go
+++ b/context.go
@@ -62,7 +62,7 @@ func NewContext(req *http.Request, res http.ResponseWriter, app *Application) *C
 func (ctx *Context) generateSession() Session {
 	s, err := ctx.App.SessionManager.NewSession()
 	if err != nil {
-		panic(err)
+		return nil
 	}
 	// Session lifetime should be configurable.
 	ctx.SetCookie("sid", s.SessionID(), 3600)

--- a/context.go
+++ b/context.go
@@ -188,10 +188,9 @@ func (ctx *Context) getRawXSRFToken() string {
 	return token
 }
 
-func checkXSRFToken(ctx *Context) bool {
+func (ctx *Context) checkXSRFToken() bool {
 	token := ctx.Request.FormValue("xsrf_token")
 	if token == "" {
-		ctx.Abort(403)
 		return false
 	}
 	_, tokenA := decodeXSRFToken(token)
@@ -216,10 +215,10 @@ func (ctx *Context) Render(file string, data ...map[string]interface{}) {
 	var renderData map[string]interface{}
 	if len(data) == 0 {
 		renderData = make(map[string]interface{})
-		renderData["xsrf_token"] = ctx.xsrfToken()
 	} else {
 		renderData = data[0]
 	}
+	renderData["xsrf_token"] = ctx.xsrfToken()
 	content, e := ctx.App.View.Render(ctx.templateLoader, file, renderData)
 	if e != nil {
 		panic(e)
@@ -232,10 +231,10 @@ func (ctx *Context) RenderFromString(tplSrc string, data ...map[string]interface
 	var renderData map[string]interface{}
 	if len(data) == 0 {
 		renderData = make(map[string]interface{})
-		renderData["xsrf_token"] = ctx.xsrfToken()
 	} else {
 		renderData = data[0]
 	}
+	renderData["xsrf_token"] = ctx.xsrfToken()
 	content, e := ctx.App.View.RenderFromString(ctx.templateLoader, tplSrc, renderData)
 	if e != nil {
 		panic(e)

--- a/context_test.go
+++ b/context_test.go
@@ -36,6 +36,52 @@ func TestContextCreate(t *testing.T) {
 	}
 }
 
+func TestParam(t *testing.T) {
+	_, app, r, w := makeTestContext("POST", "/foo/")
+	app.MiddlewareChain = NewChain()
+	app.Post("/:page/", func(ctx *Context) {
+		v, err := ctx.Param("page")
+		if err != nil {
+			t.Errorf("Could not retrieve parameter.")
+		}
+		if v != "foo" {
+			t.Errorf("Could not retrieve correct parameter.")
+		}
+		ctx.Write("success")
+	})
+	app.ServeHTTP(w, r)
+}
+
+func TestParamWithMultipleParameters(t *testing.T) {
+	_, app, r, w := makeTestContext("POST", "/dinever/golf/")
+	app.MiddlewareChain = NewChain()
+	app.Post("/:user/:repo/", func(ctx *Context) {
+		v, err := ctx.Param("user")
+		if err != nil {
+			t.Errorf("Could not retrieve parameter.")
+		}
+		if v != "dinever" {
+			t.Errorf("Could not retrieve correct parameter. %v != %v", v, "dinever")
+		}
+		v, err = ctx.Param("repo")
+		if err != nil {
+			t.Errorf("Could not retrieve parameter.")
+		}
+		if v != "golf" {
+			t.Errorf("Could not retrieve correct parameter. %v != %v", v, "golf")
+		}
+		v, err = ctx.Param("org")
+		if err == nil {
+			t.Errorf("Should have returned an error with invalid parameter query.")
+		}
+		if v != "" {
+			t.Errorf("Should have returned an empty string with invalid parameter query.")
+		}
+		ctx.Write("success")
+	})
+	app.ServeHTTP(w, r)
+}
+
 func TestCookieSet(t *testing.T) {
 	r := makeTestHTTPRequest(nil, "GET", "/foo/bar/")
 	w := httptest.NewRecorder()

--- a/error.go
+++ b/error.go
@@ -74,7 +74,7 @@ color: #ff8a00;
       <div id="header">
         <div class="container">
           <div id="title">
-            <h1>Error: 500 Internal Server Error</h1>
+            <h1>Error: {{ .Code }} {{ .Title }}</h1>
           </div>
         </div>
       </div>

--- a/middleware.go
+++ b/middleware.go
@@ -53,8 +53,8 @@ func XSRFProtectionMiddleware(next Handler) Handler {
 	fn := func(ctx *Context) {
 		xsrfEnabled, _ := ctx.App.Config.GetBool("xsrf_cookies", false)
 		if xsrfEnabled && (ctx.Request.Method == "POST" || ctx.Request.Method == "PUT" || ctx.Request.Method == "DELETE") {
-			if !checkXSRFToken(ctx) {
-				ctx.App.handleError(ctx, 403)
+			if !ctx.checkXSRFToken() {
+				ctx.Abort(403)
 				return
 			}
 		}

--- a/middleware.go
+++ b/middleware.go
@@ -88,7 +88,9 @@ func RecoverMiddleware(next Handler) Handler {
 
 func SessionMiddleware(next Handler) Handler {
 	fn := func(ctx *Context) {
-		ctx.retrieveSession()
+		if ctx.App.SessionManager != nil {
+			ctx.retrieveSession()
+		}
 		next(ctx)
 	}
 	return fn

--- a/middleware.go
+++ b/middleware.go
@@ -8,7 +8,7 @@ import (
 
 type middlewareHandler func(next Handler) Handler
 
-var defaultMiddlewares = []middlewareHandler{LoggingMiddleware, RecoverMiddleware, XSRFProtectionMiddleware}
+var defaultMiddlewares = []middlewareHandler{LoggingMiddleware, RecoverMiddleware, XSRFProtectionMiddleware, SessionMiddleware}
 
 // Chain contains a sequence of middlewares.
 type Chain struct {
@@ -81,6 +81,14 @@ func RecoverMiddleware(next Handler) Handler {
 				})
 			}
 		}()
+		next(ctx)
+	}
+	return fn
+}
+
+func SessionMiddleware(next Handler) Handler {
+	fn := func(ctx *Context) {
+		ctx.retrieveSession()
 		next(ctx)
 	}
 	return fn

--- a/session.go
+++ b/session.go
@@ -78,6 +78,10 @@ func (mgr *MemorySessionManager) GarbageCollection() {
 	time.AfterFunc(time.Duration(gcTimeInterval)*time.Second, mgr.GarbageCollection)
 }
 
+func (mgr *MemorySessionManager) Count() int {
+	return len(mgr.sessions)
+}
+
 // Session is an interface for session instance, a session instance contains
 // data needed.
 type Session interface {

--- a/session.go
+++ b/session.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"sync"
 	"time"
 )
 
@@ -22,6 +23,7 @@ type SessionManager interface {
 // MemorySessionManager is a implementation of Session Manager, which stores data in memory.
 type MemorySessionManager struct {
 	sessions map[string]*MemorySession
+	lock     sync.RWMutex
 }
 
 // NewMemorySessionManager creates a new session manager.
@@ -57,7 +59,9 @@ func (mgr *MemorySessionManager) NewSession() (Session, error) {
 		return nil, err
 	}
 	s := MemorySession{sid: sid, data: make(map[string]interface{}), createdAt: time.Now()}
+	mgr.lock.RLock()
 	mgr.sessions[sid] = &s
+	mgr.lock.RUnlock()
 	return &s, nil
 }
 

--- a/session.go
+++ b/session.go
@@ -18,6 +18,7 @@ type SessionManager interface {
 	NewSession() (Session, error)
 	Session(string) (Session, error)
 	GarbageCollection()
+	Count() int
 }
 
 // MemorySessionManager is a implementation of Session Manager, which stores data in memory.

--- a/session.go
+++ b/session.go
@@ -45,10 +45,13 @@ func (mgr *MemorySessionManager) sessionID() (string, error) {
 
 // Session gets the session instance by indicating a session id.
 func (mgr *MemorySessionManager) Session(sid string) (Session, error) {
+	mgr.lock.RLock()
 	if s, ok := mgr.sessions[sid]; ok {
 		s.createdAt = time.Now()
+		mgr.lock.RUnlock()
 		return s, nil
 	}
+	mgr.lock.RUnlock()
 	return nil, fmt.Errorf("Can not retrieve session with id %s.", sid)
 }
 
@@ -59,9 +62,9 @@ func (mgr *MemorySessionManager) NewSession() (Session, error) {
 		return nil, err
 	}
 	s := MemorySession{sid: sid, data: make(map[string]interface{}), createdAt: time.Now()}
-	mgr.lock.RLock()
+	mgr.lock.Lock()
 	mgr.sessions[sid] = &s
-	mgr.lock.RUnlock()
+	mgr.lock.Unlock()
 	return &s, nil
 }
 


### PR DESCRIPTION
1. Moved Session into a middleware.
1. Add mutex in MemorySessionManager to avoid the race condition. Fixes #14 
1. Disable session by default
1. Add method `Count` to `SessionManager` interface
1. Improved test cases for sessions and XSRF protection