### PR TITLE
[feat] Implement optional ending slash for routes

### DIFF
--- a/router.go
+++ b/router.go
@@ -81,12 +81,22 @@ func (router *router) AddRoute(method string, path string, handler HandlerFunc) 
 		rootNode *node
 		ok       bool
 	)
-	parts, names := splitURLPath(path)
 	if rootNode, ok = router.trees[method]; !ok {
 		rootNode = &node{}
 		router.trees[method] = rootNode
 	}
+
+	parts, names := splitURLPath(path)
 	rootNode.addRoute(parts, names, handler)
+
+	if path == "/" {
+	} else if path[len(path) - 1] != '/' {
+		parts, names := splitURLPath(path + "/")
+		rootNode.addRoute(parts, names, handler)
+	} else {
+		parts, names := splitURLPath(path[:len(path) - 1])
+		rootNode.addRoute(parts, names, handler)
+	}
 	rootNode.optimizeRoutes()
 }
 

--- a/router_test.go
+++ b/router_test.go
@@ -133,3 +133,47 @@ func TestPathNotFound(t *testing.T) {
 		}
 	}
 }
+
+
+
+
+func TestRouterWithOptionalEndingSlash(t *testing.T) {
+	var cases = []route{
+		// Path with optional ending slash
+		{"GET", "/", "/", nil},
+		{"GET", "/events", "/events/", nil},
+		{"GET", "/repos/:owner/:repo/events", "/repos/dinever/golf/events/", map[string]string{"owner": "dinever", "repo": "golf"}},
+		{"GET", "/networks/:owner/:repo/events/", "/networks/dinever/golf/events", map[string]string{"owner": "dinever", "repo": "golf"}},
+		{"GET", "/orgs/:org/events/", "/orgs/golf/events", map[string]string{"org": "golf"}},
+		{"GET", "/users/:user/received_events", "/users/dinever/received_events/", nil},
+		{"GET", "/users/:user/received_events/public", "/users/dinever/received_events/public", nil},
+	}
+
+	router := newRouter()
+	for _, route := range cases {
+		router.AddRoute(route.method, route.path, handler)
+	}
+
+	for _, route := range cases {
+		_, param, err := router.FindRoute(route.method, route.testPath)
+		if err != nil {
+			t.Errorf("Can not find route: %v", route.testPath)
+		}
+
+		for key, expected := range route.params {
+			val, err := param.ByName(key)
+			if err != nil {
+				t.Errorf("Can not retrieve parameter from route %v: %v", route.testPath, key)
+			} else {
+				assertStringEqual(t, expected, val)
+			}
+			val, err = param.ByName(key)
+			if err != nil {
+				t.Errorf("Can not retrieve parameter from route %v: %v", route.testPath, key)
+			} else {
+				assertStringEqual(t, expected, val)
+			}
+		}
+	}
+}
+

--- a/router_test.go
+++ b/router_test.go
@@ -134,9 +134,6 @@ func TestPathNotFound(t *testing.T) {
 	}
 }
 
-
-
-
 func TestRouterWithOptionalEndingSlash(t *testing.T) {
 	var cases = []route{
 		// Path with optional ending slash
@@ -176,4 +173,3 @@ func TestRouterWithOptionalEndingSlash(t *testing.T) {
 		}
 	}
 }
-


### PR DESCRIPTION
```
app.Get("/events", testHandler)
```

Both `/events` and `/events/` work now.