### PR TITLE
Add JSONIndent method

### DIFF
--- a/context.go
+++ b/context.go
@@ -167,6 +167,16 @@ func (ctx *Context) JSON(obj interface{}) {
 	ctx.Send(json)
 }
 
+// JSONIndent Sends a JSON response, indenting the JSON as desired.
+func (ctx *Context) JSONIndent(obj interface{}, prefix, indent string) {
+	jsonIndented, err := json.MarshalIndent(obj, prefix, indent)
+	if err != nil {
+		panic(err)
+	}
+	ctx.SetHeader("Content-Type", "application/json")
+	ctx.Send(jsonIndented)
+}
+
 // Send the response immediately. Set `ctx.IsSent` to `true` to make
 // sure that the response won't be sent twice.
 func (ctx *Context) Send(body interface{}) {

--- a/context_test.go
+++ b/context_test.go
@@ -385,3 +385,28 @@ func TestJSON(t *testing.T) {
 		assertEqual(t, w.HeaderMap.Get("Content-Type"), `application/json`)
 	}
 }
+
+func TestJSONIndent(t *testing.T) {
+	cases := []struct {
+		input  map[string]interface{}
+		output string
+	}{
+		{
+			map[string]interface{}{"status": "success", "code": 200},
+			`{
+  "code": 200,
+  "status": "success"
+}`,
+		},
+	}
+
+	for _, c := range cases {
+		r := makeTestHTTPRequest(nil, "GET", "/")
+		w := httptest.NewRecorder()
+		app := New()
+		ctx := NewContext(r, w, app)
+		ctx.JSONIndent(c.input, "", "  ")
+		assertEqual(t, w.Body.String(), c.output)
+		assertEqual(t, w.HeaderMap.Get("Content-Type"), `application/json`)
+	}
+}


### PR DESCRIPTION
I've been (slowly) working on [https://github.com/dinever/dingo/issues/6](https://github.com/dinever/dingo/issues/6), and noticed that the output of `ctx.JSON` wasn't very human-readable, since it just uses `json.MarshalIndent`. I really like the way [GitHub](https://api.github.com/) has a sort of self-documenting API, and has easy-to-read JSON output, since it is formatted nicely. This PR adds support for the `json.MarshalIndent` method inside `ctx`, so that users can choose how to format their JSON output.