### PR TITLE
Fixes default HTTP redirection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ go:
   - 1.4
   - 1.5
   - 1.6
+  - 1.7
+  - 1.8
 
 before_install:
   - go get github.com/mattn/goveralls

--- a/context.go
+++ b/context.go
@@ -126,9 +126,14 @@ func (ctx *Context) Param(key string) string {
 	return val
 }
 
-// Redirect method sets the response as a 301 redirection.
-// If you need a 302 redirection, please do it by setting the Header manually.
+// Redirect method sets the response as a 302 redirection.
 func (ctx *Context) Redirect(url string) {
+	ctx.SetHeader("Location", url)
+	ctx.SendStatus(302)
+}
+
+// Redirect301 method sets the response as a 301 redirection.
+func (ctx *Context) Redirect301(url string) {
 	ctx.SetHeader("Location", url)
 	ctx.SendStatus(301)
 }

--- a/context.go
+++ b/context.go
@@ -116,7 +116,7 @@ func (ctx *Context) Query(key string, index ...int) (string, error) {
 		}
 		return val[0], nil
 	}
-	return "", errors.New("Query key not found.")
+	return "", errors.New("Query key not found")
 }
 
 // Param method retrieves the parameters from url
@@ -197,7 +197,7 @@ func (ctx *Context) Send(body interface{}) {
 	case *bytes.Buffer:
 		ctx.Response.Write(body.(*bytes.Buffer).Bytes())
 	default:
-		panic(fmt.Errorf("Body type not supported."))
+		panic(fmt.Errorf("Body type not supported"))
 	}
 	ctx.IsSent = true
 }
@@ -283,7 +283,7 @@ func (ctx *Context) xsrfToken() string {
 // Render a template file using the built-in Go template engine.
 func (ctx *Context) Render(file string, data ...map[string]interface{}) {
 	if ctx.templateLoader == "" {
-		panic(fmt.Errorf("Template loader has not been set."))
+		panic(fmt.Errorf("Template loader has not been set"))
 	}
 	var renderData map[string]interface{}
 	if len(data) == 0 {

--- a/context_test.go
+++ b/context_test.go
@@ -280,6 +280,16 @@ func TestRedirection(t *testing.T) {
 	ctx := NewContext(r, w, app)
 	ctx.Redirect("/foo")
 	assertEqual(t, w.Header().Get("Location"), `/foo`)
+	assertEqual(t, w.Code, 302)
+}
+
+func TestRedirection301(t *testing.T) {
+	r := makeTestHTTPRequest(nil, "GET", "/")
+	w := httptest.NewRecorder()
+	app := New()
+	ctx := NewContext(r, w, app)
+	ctx.Redirect301("/foo")
+	assertEqual(t, w.Header().Get("Location"), `/foo`)
 	assertEqual(t, w.Code, 301)
 }
 

--- a/session.go
+++ b/session.go
@@ -39,7 +39,7 @@ func (mgr *MemorySessionManager) sessionID() (string, error) {
 	b := make([]byte, sessionIDLength)
 	n, err := rand.Read(b)
 	if n != len(b) || err != nil {
-		return "", fmt.Errorf("Could not successfully read from the system CSPRNG.")
+		return "", fmt.Errorf("Could not successfully read from the system CSPRNG")
 	}
 	return hex.EncodeToString(b), nil
 }
@@ -53,7 +53,7 @@ func (mgr *MemorySessionManager) Session(sid string) (Session, error) {
 		return s, nil
 	}
 	mgr.lock.RUnlock()
-	return nil, fmt.Errorf("Can not retrieve session with id %s.", sid)
+	return nil, fmt.Errorf("Can not retrieve session with id %s", sid)
 }
 
 // NewSession creates and returns a new session.


### PR DESCRIPTION
Changes:

- Changed default HTTP redirection status to `302`, fixes #26 
- Added `Context.Redirect301` for `301` redirection
- Fixed several golint warnings
- Added Go 1.7 and 1.8 to `.travis.yml`